### PR TITLE
fix: Pass arguments to entry points

### DIFF
--- a/packages/tests/lib/kubernetes.js
+++ b/packages/tests/lib/kubernetes.js
@@ -9,9 +9,9 @@ function getk8s() {
   return kc.makeApiClient(k8s.CoreV1Api)
 }
 
-const spec = (image, name, labels = {}, environment = {}) => {
+const spec = (image, name, labels = {}, arguments = []) => {
   return {
-    apiVersions: "core/v1",
+    apiVersion: "v1",
     kind: "Pod",
     metadata: { name, labels },
     spec: {
@@ -21,10 +21,7 @@ const spec = (image, name, labels = {}, environment = {}) => {
         {
           name,
           image: image,
-          env: Object.entries(environment).map(([name, value]) => ({
-            name,
-            value,
-          })),
+          args: arguments
         },
       ],
     },
@@ -32,8 +29,8 @@ const spec = (image, name, labels = {}, environment = {}) => {
 }
 
 const namespace = 'tests'
-const startTest = (image, name, id, environment) => {
-  const body = spec(image, name, { job_id: id }, environment)
+const startTest = (image, name, id, arguments) => {
+  const body = spec(image, name, { job_id: id }, arguments)
   const k8sApi = getk8s()
 
   return k8sApi

--- a/packages/tests/tests/dns/test-dns.py
+++ b/packages/tests/tests/dns/test-dns.py
@@ -10,7 +10,6 @@ if(len(sys.argv) != 2):
   print("Error: Expected 1 argument (url)")
   sys.exit(1)
 
-print(sys.argv)
 
 url = sys.argv[1]
 domain = urlparse(url).netloc

--- a/packages/tests/tests/dns/test-dns.py
+++ b/packages/tests/tests/dns/test-dns.py
@@ -3,16 +3,23 @@
 import sys
 import json
 import dns.resolver
+import os
+from urllib.parse import urlparse
 
 if(len(sys.argv) != 2):
-  print("Error")
+  print("Error: Expected 1 argument (url)")
   sys.exit(1)
+
+print(sys.argv)
+
+url = sys.argv[1]
+domain = urlparse(url).netloc
 
 response = {}
 response['ipv6'] = {}
 response['dnssec'] = {}
 try:
-  answer = dns.resolver.resolve(sys.argv[1], "AAAA")
+  answer = dns.resolver.resolve(domain, "AAAA")
   response['ipv6']['status'] = "OK"
   response['ipv6']['data'] = []
   for record in answer:
@@ -25,7 +32,7 @@ except dns.resolver.NXDOMAIN:
   response['ipv6']['data'] = ["NO SUCH DOMAIN"]
 
 try:
-  answer = dns.resolver.resolve(sys.argv[1], "DS")
+  answer = dns.resolver.resolve(domain, "DS")
   response['dnssec']['status'] = "OK"
   response['dnssec']['data'] = []
   for record in answer:
@@ -38,5 +45,3 @@ except dns.resolver.NXDOMAIN:
   response['dnssec']['data'] = ["NO SUCH DOMAIN"]
 
 print(json.dumps(response))
-
-

--- a/packages/tests/tests/dns/worker.js
+++ b/packages/tests/tests/dns/worker.js
@@ -6,7 +6,7 @@ module.exports = (connection) => new Worker(queue.name, async (job) => {
   await job.log('Starting DNS')
   const {id, data: { url }} = job
   try {
-    const pod = await startTest('netnodse/robust-dns', `dns-${id}`, id, { url })
+    const pod = await startTest('netnodse/robust-dns', `dns-${id}`, id, [url])
     await pod.done()
     const logs = await pod.log()
     job.log(logs)

--- a/packages/tests/tests/tls/Dockerfile
+++ b/packages/tests/tests/tls/Dockerfile
@@ -1,4 +1,5 @@
-FROM bash
-COPY run.sh .
-RUN chmod +x run.sh
-CMD run.sh
+FROM alpine
+RUN apk update && apk add curl bash
+COPY run.sh /test/run.sh
+RUN chmod +x /test/run.sh
+ENTRYPOINT ["/test/run.sh"]

--- a/packages/tests/tests/tls/run.sh
+++ b/packages/tests/tests/tls/run.sh
@@ -1,5 +1,5 @@
-#!/usr/local/bin/bash
+#!/usr/bin/env bash
 
-curl ${url}
+curl --silent "$1"
 
 # parse result and emit json

--- a/packages/tests/tests/tls/worker.js
+++ b/packages/tests/tests/tls/worker.js
@@ -6,7 +6,7 @@ module.exports = (connection) => new Worker(queue.name, async (job) => {
   await job.log("Starting tls")
   const {id, data: { url }} = job
   try {
-    const pod = await startTest('netnodse/robust-tls', `tls-${id}`, id, { url })
+    const pod = await startTest('netnodse/robust-tls', `tls-${id}`, id, [url])
     await pod.done()
     const logs = await pod.log()
     job.log(logs)


### PR DESCRIPTION
Examples are now correct for tests, and the test runner passes arguments to the entry point.

Also a few fixes for the tests.

Result: Tests finish successfully and results are passed to bullmq