### PR TITLE
chore: increase deadline for pods

### DIFF
--- a/packages/tests/lib/kubernetes.js
+++ b/packages/tests/lib/kubernetes.js
@@ -21,7 +21,7 @@ const spec = (image, name, labels = {}, arguments = []) => {
     kind: "Pod",
     metadata: { name, labels },
     spec: {
-      activeDeadlineSeconds: 25,
+      activeDeadlineSeconds: 60,
       restartPolicy: "Never",
       containers: [
         {


### PR DESCRIPTION
Since we're not running tests in sequence, but all at once, it seems like 25 seconds is not enough for some tests (zonemaster) -- here's a temp fix