### PR TITLE
tests/hsts: include host in failure JSON response

### DIFF
--- a/packages/tests/tests/hsts/doit.sh
+++ b/packages/tests/tests/hsts/doit.sh
@@ -6,7 +6,7 @@ HEADER=$(curl -s -D- https://"$HOST"/ | grep -i Strict-Transport-Security)
 
 # TODO: look at max-age in the header and options
 if [ -z "$HEADER" ]; then
-   echo "{ \"passed\": false, \"details\": { \"tested_url\": \"https://$HOST/\" } }"
+   echo "{ \"passed\": false, \"details\": { \"tested_url\": \"https://$HOST/\", \"host\": \"$HOST\" } }"
 else
    echo "{ \"passed\": true, \"details\": { \"tested_url\": \"https://$HOST/\", \"host\": \"$HOST\" } }"
 fi


### PR DESCRIPTION
This addresses the missing value in the failure message, as indicated by the "undefined" below:

>Detta innebär att en användare som skriver **undefined** utan https://

Ref: https://robust.netnod.se/test/a6bdb88e-1fdb-48a5-b4c3-94c618e8bd0b