### PR TITLE
Turned off IPv6 while waiting for k8s cluster

### DIFF
--- a/packages/tests/tests/zonemaster/doit.sh
+++ b/packages/tests/tests/zonemaster/doit.sh
@@ -20,7 +20,7 @@ while [ "x$NS" = x ]; do
     NS=`dig ${ARGDOMAIN} NS +short`
 done
 
-zonemaster-cli "${ARGDOMAIN}" --json_stream --json_translate --locale sv_SE.UTF-8 | tr -d '\n' | sed 's/}{/}, {/g' > /tmp/foo
+zonemaster-cli "${ARGDOMAIN}" --no-ipv6 --json_stream --json_translate --locale sv_SE.UTF-8 | tr -d '\n' | sed 's/}{/}, {/g' > /tmp/foo
 
 ## Output should be
 # '{ passed: true/false, details: { object } }'


### PR DESCRIPTION
Turned off IPv6 because it generates false error messages as the k8s cluster is not able to send DNS queries over IPv6. I.e. the error is on the sending side and not the target side of the DNS communication.