### PR TITLE
chore: Get rid of BASE_URL env variable

### DIFF
--- a/k8s/web.yaml
+++ b/k8s/web.yaml
@@ -29,8 +29,6 @@ spec:
             - containerPort: 3000
           resources: {}
           env:
-            - name: BASE_URL
-              value: "https://robust.netnod.se"
             - name: REDIS_PASS
               valueFrom:
                 secretKeyRef:

--- a/packages/web/.env.template
+++ b/packages/web/.env.template
@@ -6,9 +6,6 @@ DATABASE_URL="postgres://postgres:PG-PASSWORD@localhost:5432/robust-tjanst"
 # insert redis password from the k8s secret redis
 REDIS_URL="redis://:REDIS-PASSWORD@localhost:6379"
 
-# The URL that the application is served from
-BASE_URL=http://localhost:3000
-
 # Comma separated, passed to https://github.com/crypto-utils/keygrip
 # Generate with eg. node -e "console.log(require('crypto').randomBytes(32).toString('base64'))"
 # ps: 1 is enough, in fact you can't give multiple

--- a/packages/web/src/index.js
+++ b/packages/web/src/index.js
@@ -23,7 +23,7 @@ const fake = require('./fake')
 const { InvalidSessionError } = require('./errors')
 const { format } = require('date-fns')
 
-const {BASE_URL, SIGNED_COOKIE_KEYS, NODE_ENV} = process.env
+const {SIGNED_COOKIE_KEYS, NODE_ENV} = process.env
 
 const app = new Koa()
 
@@ -130,8 +130,11 @@ router.get('fake_test', '/results', fake.test)
 
 // Template helpers. These functions are callable inside views
 app.use(async (ctx, next) => {
+  const { host, protocol } = ctx.request
+  const base_url = `${protocol}://${host}`
+
   ctx.state.absolutePath = (relativePath) => {
-    return new URL(relativePath, BASE_URL).toString()
+    return new URL(relativePath, base_url).toString()
   }
 
   ctx.state.namedPath = (name, ...args) => {
@@ -143,7 +146,7 @@ app.use(async (ctx, next) => {
 
   ctx.state.namedURL = (name, ...args) => {
     const path = ctx.state.namedPath(name, ...args)
-    return new URL(path, BASE_URL).toString()
+    return new URL(path, base_url).toString()
   }
 
   ctx.state.formatTimestamp = (ts) => {

--- a/packages/web/src/views/tests/loading.pug
+++ b/packages/web/src/views/tests/loading.pug
@@ -21,7 +21,7 @@ block content
     <lottie-player src="/img/loading-animation.json" background="transparent" speed="1" class="mt-0 h-1/5 w-1/5 self-center mb-40" loop autoplay></lottie-player>
 
     script.
-      const statusURL = "#{absolutePath(namedPath('test_loading_status', test_id))}"
+      const statusURL = "#{namedPath('test_loading_status', test_id)}"
 
       const counter = document.querySelector('#counter')
       const total = document.querySelector('#total')


### PR DESCRIPTION
Should never have been part of k8s/web.yaml in the first place, but since we don't need to know our own URL outside of an HTTP request context anymore (such as sending an email in a cronjob) we don't need this at all. Instead, read protocol & hostname from the incoming request and use that.